### PR TITLE
Pass value and onChangeText down to TextInput

### DIFF
--- a/lib/TextField.js
+++ b/lib/TextField.js
@@ -85,7 +85,6 @@ export default class TextField extends Component {
             onBlur && onBlur();
           }}
           onChangeText={(text) => {
-            this.setState({text});
             onChangeText && onChangeText(text);
           }}
           onChange={(event) => {
@@ -95,7 +94,7 @@ export default class TextField extends Component {
             onChange && onChange(event);
           }}
           ref="input"
-          value={this.state.text}
+          value={value}
           {...props}
         />
         <Underline


### PR DESCRIPTION
Let the user control the value and state of the TextInput as opposed to controlling it internally with component state.